### PR TITLE
Add readme and repository URLs to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 name = "upskill"
 version = "0.2.1"
 description = "Generate and evaluate agent skills"
+readme = "README.md"
 requires-python = ">=3.13.5,<3.14"
 dependencies = [
     "click>=8.1",
@@ -11,6 +12,10 @@ dependencies = [
     "pyyaml>=6.0",
     "rich>=13.0",
 ]
+
+[project.urls]
+Homepage = "https://github.com/huggingface/upskill"
+Repository = "https://github.com/huggingface/upskill"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
## Summary

Adds project metadata to `pyproject.toml` so PyPI displays:
- The README content on the package page
- Links to the GitHub repository (Homepage and Repository URLs)

## Changes

- Added `readme = "README.md"` field
- Added `[project.urls]` section with Homepage and Repository links

## Verification

- Package builds successfully with `uv build`
- Metadata appears correctly in built wheel:
  ```
  Project-URL: Homepage, https://github.com/huggingface/upskill
  Project-URL: Repository, https://github.com/huggingface/upskill
  ```
- All tests pass
- Linting passes

Closes #13