### PR TITLE
Remove non-existent --eval-provider and --eval-base-url from generate docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,6 @@ upskill generate TASK [OPTIONS]
 - `-o, --output PATH` - Output directory for skill
 - `--no-eval` - Skip evaluation and refinement
 - `--eval-model MODEL` - Different model to evaluate skill on
-- `--eval-provider [anthropic|openai|generic]` - API provider for eval model
-- `--eval-base-url URL` - Custom API endpoint for eval model
 - `--runs-dir PATH` - Directory for run logs (default: ./runs)
 - `--log-runs / --no-log-runs` - Log run data (default: enabled)
 
@@ -83,10 +81,8 @@ upskill generate "add more error handling examples" --from ./skills/api-errors/
 # Generate from an agent trace file (auto-detected as file)
 upskill generate "document the pattern" --from ./trace.json
 
-# Evaluate on local model (llama.cpp server)
-upskill generate "parse YAML" \
-    --eval-model "unsloth/GLM-4.7-Flash-GGUF:Q4_0" \
-    --eval-base-url http://localhost:8080/v1
+# Skip evaluation during generation (evaluate separately with upskill eval)
+upskill generate "parse YAML" --no-eval
 ```
 
 **Output:**

--- a/src/upskill/cli.py
+++ b/src/upskill/cli.py
@@ -220,10 +220,9 @@ def generate(
 
         upskill generate "extract patterns" --from trace.json
 
-        # Evaluate on a local model (Ollama):
+        # Skip evaluation (evaluate separately with upskill eval)
 
-        upskill generate "parse YAML" --eval-model llama3.2:latest \\
-            --eval-base-url http://localhost:11434/v1
+        upskill generate "parse YAML" --no-eval
 
         upskill generate "document code" --no-log-runs
     """


### PR DESCRIPTION
## Summary

Fixes documentation that references options that no longer exist in the `generate` command.

The `--eval-provider` and `--eval-base-url` options were removed from the `generate` command in commit 542b3af, but the documentation was not updated.

## Problem

Users following the documentation get errors:
```
Error: No such option: --eval-base-url Did you mean --eval-model?
Error: No such option: --eval-provider Did you mean --eval-model?
```

## Changes

- Remove `--eval-provider` and `--eval-base-url` from README options list
- Update example to use `--no-eval` instead of non-existent options  
- Fix CLI help docstring to match actual available options

## Verification

- `upskill generate --help` now shows only valid options
- All examples use options that actually exist
- Tests pass
- Linting passes

Note: For local model evaluation, users can use `upskill eval` with `--base-url` after generating with `--no-eval`.