### PR TITLE
fix: specify utf-8 encoding in read_text calls on Windows

### DIFF
--- a/src/upskill/cli.py
+++ b/src/upskill/cli.py
@@ -1827,7 +1827,7 @@ def list_cmd(skills_dir: str | None, verbose: bool):
 
     for skill_dir in sorted(skills):
         skill_md = skill_dir / "SKILL.md"
-        content = skill_md.read_text()
+        content = skill_md.read_text(encoding="utf-8")
         lines = content.split("\n")
         name = skill_dir.name
 
@@ -1847,7 +1847,7 @@ def list_cmd(skills_dir: str | None, verbose: bool):
                 refs_branch = skill_branch.add("references/")
                 for ref_file in sorted(refs_dir.iterdir()):
                     if ref_file.is_file():
-                        ref_tokens = int(len(ref_file.read_text().split()) * 1.3)
+                        ref_tokens = int(len(ref_file.read_text(encoding="utf-8").split()) * 1.3)
                         total_tokens += ref_tokens
                         refs_branch.add(f"{ref_file.name} [dim](~{ref_tokens} tokens)[/dim]")
 

--- a/src/upskill/config.py
+++ b/src/upskill/config.py
@@ -168,7 +168,7 @@ class Config(BaseModel):
             return cls()
 
         if config_path.exists():
-            with open(config_path) as f:
+            with open(config_path, encoding="utf-8") as f:
                 data = yaml.safe_load(f) or {}
             # Convert path strings to Path objects
             if "skills_dir" in data and isinstance(data["skills_dir"], str):
@@ -192,7 +192,7 @@ class Config(BaseModel):
         data["runs_dir"] = str(self.runs_dir)
         if self.fastagent_config:
             data["fastagent_config"] = str(self.fastagent_config)
-        with open(config_path, "w") as f:
+        with open(config_path, "w", encoding="utf-8") as f:
             yaml.dump(data, f, default_flow_style=False)
 
     @property

--- a/src/upskill/logging.py
+++ b/src/upskill/logging.py
@@ -351,7 +351,7 @@ def summarize_runs_to_csv(runs_folder: Path, output_path: Path | None = None) ->
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
-    with open(output_path, "w", newline="") as outfile:
+    with open(output_path, "w", newline="", encoding="utf-8") as outfile:
         writer = csv.DictWriter(outfile, fieldnames=FIELDNAMES)
         writer.writeheader()
 

--- a/src/upskill/models.py
+++ b/src/upskill/models.py
@@ -231,7 +231,7 @@ def _load_skill_state(path: Path) -> SkillState:
     if not meta_path.exists():
         return state
 
-    meta_dict = json.loads(meta_path.read_text())
+    meta_dict = json.loads(meta_path.read_text(encoding="utf-8"))
     if "metadata" in meta_dict:
         state.metadata = SkillMetadata.model_validate(meta_dict["metadata"])
     if "tests" in meta_dict:
@@ -246,7 +246,7 @@ def _load_artifact_directory(path: Path, directory_name: str) -> dict[str, str]:
         return {}
 
     return {
-        file_path.name: file_path.read_text()
+        file_path.name: file_path.read_text(encoding="utf-8")
         for file_path in directory.iterdir()
         if file_path.is_file()
     }
@@ -328,7 +328,7 @@ class Skill(BaseModel):
         if not skill_md_path.exists():
             raise FileNotFoundError(f"SKILL.md not found in {path}")
 
-        content = skill_md_path.read_text()
+        content = skill_md_path.read_text(encoding="utf-8")
         (
             name,
             description,

--- a/tests/test_execution_backends.py
+++ b/tests/test_execution_backends.py
@@ -160,7 +160,7 @@ async def test_local_fast_agent_executor_preserves_artifacts_and_parses_results(
     assert (request.artifact_dir / "request.json").exists()
     assert (request.artifact_dir / "stdout.txt").exists()
     assert (request.artifact_dir / "stderr.txt").exists()
-    assert (request.artifact_dir / "workspace" / "context.txt").read_text() == "hello"
+    assert (request.artifact_dir / "workspace" / "context.txt").read_text(encoding="utf-8") == "hello"
     assert (request.artifact_dir / "workspace" / "fastagent.config.yaml").exists()
     assert (request.artifact_dir / "cards" / "evaluator.md").exists()
     assert not (request.artifact_dir / "cards" / "skill_gen.md").exists()
@@ -297,7 +297,7 @@ async def test_remote_fast_agent_executor_preserves_artifacts_and_parses_results
     assert (request.artifact_dir / "stdout.txt").exists()
     assert (request.artifact_dir / "stderr.txt").exists()
     assert (request.artifact_dir / "remote_output" / "results" / "request_1.json").exists()
-    assert (request.artifact_dir / "workspace" / "context.txt").read_text() == "remote hello"
+    assert (request.artifact_dir / "workspace" / "context.txt").read_text(encoding="utf-8") == "remote hello"
     assert not (request.artifact_dir / "cards" / "skill_gen.md").exists()
     assert not (request.artifact_dir / "cards" / "test_gen.md").exists()
     assert submitted_labels == {
@@ -353,7 +353,7 @@ async def test_remote_fast_agent_executor_submit_preserves_artifacts(
     assert not (request.artifact_dir / "cards" / "skill_gen.md").exists()
     assert not (request.artifact_dir / "cards" / "test_gen.md").exists()
     assert (request.artifact_dir / "skills" / "write-good-prs" / "SKILL.md").exists()
-    submitted_job = json.loads((request.artifact_dir / "submitted_job.json").read_text())
+    submitted_job = json.loads((request.artifact_dir / "submitted_job.json").read_text(encoding="utf-8"))
     assert submitted_job["job_id"] == "evalstate/job-123"
     assert submitted_job["run_id"] == "run-456"
 


### PR DESCRIPTION
## Summary
Fixes Windows encoding issues caused by calling `read_text()` without specifying `encoding="utf-8"`.

On Windows, `Path.read_text()` can default to cp1252, which may break when reading UTF-8 files. This PR updates the relevant call(s) to use UTF-8 explicitly.

Fixes #18