### PR TITLE
Harden PMD ZIP extraction

### DIFF
--- a/scripts/cpd.py
+++ b/scripts/cpd.py
@@ -27,7 +27,7 @@ import tarfile
 import urllib.request
 import zipfile
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Final
 
 JRE_VERSION: Final = "17.0.9+9"
@@ -125,16 +125,48 @@ def download_file(url: str, destination: Path, description: str) -> None:
     print(f"  Downloaded to {destination}")
 
 
+def is_unsafe_archive_member(member_name: str) -> bool:
+    """Detect archive paths that are absolute or traverse parents on POSIX or Windows."""
+    posix_path = PurePosixPath(member_name)
+    windows_path = PureWindowsPath(member_name)
+    return (
+        posix_path.is_absolute()
+        or windows_path.is_absolute()
+        or ".." in posix_path.parts
+        or ".." in windows_path.parts
+    )
+
+
 def extract_tar_archive(archive_path: Path, destination: Path) -> None:
     """Extract a tar.gz archive while guarding against path traversal."""
     destination_root = destination.resolve()
     with tarfile.open(archive_path, "r:gz") as archive:
         for member in archive.getmembers():
+            if is_unsafe_archive_member(member.name):
+                message = f"Unsafe path in archive {archive_path}: {member.name}"
+                raise RuntimeError(message)
             member_path = (destination_root / member.name).resolve()
             try:
                 member_path.relative_to(destination_root)
             except ValueError as error:
                 message = f"Unsafe path in archive {archive_path}: {member.name}"
+                raise RuntimeError(message) from error
+        archive.extractall(destination_root)
+
+
+def extract_zip_archive(archive_path: Path, destination: Path) -> None:
+    """Extract a zip archive while guarding against path traversal."""
+    destination_root = destination.resolve()
+    with zipfile.ZipFile(archive_path, "r") as archive:
+        for member in archive.infolist():
+            if is_unsafe_archive_member(member.filename):
+                message = f"Unsafe path in archive {archive_path}: {member.filename}"
+                raise RuntimeError(message)
+            member_path = (destination_root / member.filename).resolve()
+            try:
+                member_path.relative_to(destination_root)
+            except ValueError as error:
+                message = f"Unsafe path in archive {archive_path}: {member.filename}"
                 raise RuntimeError(message) from error
         archive.extractall(destination_root)
 
@@ -193,8 +225,7 @@ def ensure_pmd(platform_config: PlatformConfig) -> Path:
         download_file(PMD_URL, archive_path, f"PMD {PMD_VERSION}")
 
     print("Extracting PMD...")
-    with zipfile.ZipFile(archive_path, "r") as archive:
-        archive.extractall(TOOLS_DIR)
+    extract_zip_archive(archive_path, TOOLS_DIR)
 
     if platform_config.system != "windows":
         pmd_bin.chmod(0o755)

--- a/tests/test_cpd.py
+++ b/tests/test_cpd.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+import zipfile
 from typing import TYPE_CHECKING
 
+import pytest
+
+from scripts import cpd
 from scripts.cpd import build_cpd_command, resolve_cli_exit_code, resolve_platform
 
 if TYPE_CHECKING:
@@ -55,3 +59,27 @@ def test_resolve_cli_exit_code_honors_check_mode() -> None:
     assert resolve_cli_exit_code(cpd_exit_code=4, check=False) == 0
     assert resolve_cli_exit_code(cpd_exit_code=4, check=True) == 1
     assert resolve_cli_exit_code(cpd_exit_code=7, check=True) == 7
+
+
+@pytest.mark.parametrize("unsafe_member", ["../escape.txt", "..\\escape.txt", "C:\\tmp\\escape.txt"])
+def test_ensure_pmd_rejects_zip_path_traversal(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    unsafe_member: str,
+) -> None:
+    tools_dir = tmp_path / "tools"
+    pmd_dir = tools_dir / f"pmd-bin-{cpd.PMD_VERSION}"
+    tools_dir.mkdir()
+    archive_path = tools_dir / f"pmd-{cpd.PMD_VERSION}.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr(f"pmd-bin-{cpd.PMD_VERSION}/bin/pmd", "#!/bin/sh\n")
+        archive.writestr(unsafe_member, "bad")
+
+    monkeypatch.setattr(cpd, "TOOLS_DIR", tools_dir)
+    monkeypatch.setattr(cpd, "PMD_DIR", pmd_dir)
+    monkeypatch.setattr(cpd, "download_file", lambda *_args, **_kwargs: None)
+
+    with pytest.raises(RuntimeError, match="Unsafe path in archive"):
+        cpd.ensure_pmd(resolve_platform(system="linux", arch="x86_64"))
+
+    assert not (tmp_path / "escape.txt").exists()


### PR DESCRIPTION
## Summary
- validate PMD ZIP archive members before extraction
- reject POSIX and Windows-style absolute or parent-traversing paths
- reuse the stricter member check for tar archives as well

## Testing
- `uv run --no-project --with pytest pytest -q tests/test_cpd.py -k pmd`
- `uv run --no-project --with pytest pytest -q tests/test_cpd.py`
- `uv run --no-project --with ruff ruff check scripts/cpd.py tests/test_cpd.py`
- `python3 -m py_compile scripts/cpd.py tests/test_cpd.py`
- `git diff --check`